### PR TITLE
[Revision] Integration Tests: SSL Certificates Are Now Generated During Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -471,6 +471,20 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.81</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.81</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <reporting>

--- a/src/test/java/biz/paluch/logging/gelf/SslCertHelper.java
+++ b/src/test/java/biz/paluch/logging/gelf/SslCertHelper.java
@@ -1,0 +1,108 @@
+package biz.paluch.logging.gelf;
+
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.math.BigInteger;
+import java.security.*;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+
+public class SslCertHelper {
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    public static void generateKeystore(String keystorePath, char[] password) throws Exception {
+        // 1. CA Keypair
+        final KeyPair caKeyPair = generateKeyPair();
+
+        // 2. CA Certificate
+        final X509Certificate caCert = generateCertificate(
+                "CN=CA Certificate,O=logstash-gelf,ST=Unknown,C=NN",
+                caKeyPair,
+                7300,
+                null,
+                null
+        );
+
+        // 3. Server Keypair
+        final KeyPair serverKeyPair = generateKeyPair();
+
+        // 4. Server Certificate signed by CA
+        final X509Certificate serverCert = generateCertificate(
+                "CN=localhost,O=logstash-gelf,ST=Unknown,C=NN",
+                serverKeyPair,
+                375,
+                caKeyPair,
+                caCert
+        );
+
+        // 5. Keystore mit CA + Server
+        final KeyStore ks = KeyStore.getInstance("JKS");
+        ks.load(null, null);
+
+        ks.setKeyEntry("server", serverKeyPair.getPrivate(), password, new java.security.cert.Certificate[]{serverCert, caCert});
+        ks.setCertificateEntry("ca", caCert);
+
+        try (FileOutputStream fos = new FileOutputStream(keystorePath)) {
+            ks.store(fos, password);
+        }
+    }
+
+    public static File createTestKeystoreFile(final String password) throws Exception {
+        final File tempFile = File.createTempFile("test-keystore", ".jks");
+
+        generateKeystore(tempFile.getAbsolutePath(), password.toCharArray());
+
+        return tempFile;
+    }
+
+    private static KeyPair generateKeyPair() throws Exception {
+        final KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA", "BC");
+        keyGen.initialize(2048);
+        return keyGen.generateKeyPair();
+    }
+
+    private static X509Certificate generateCertificate(
+            String dn,
+            KeyPair pair,
+            int days,
+            KeyPair caKeyPair,
+            X509Certificate caCert
+    ) throws Exception {
+
+        final X500Name issuer = (caCert == null) ? new X500Name(dn) : new X500Name(caCert.getSubjectX500Principal().getName());
+        final X500Name subject = new X500Name(dn);
+
+        final PublicKey publicKey = pair.getPublic();
+        final PrivateKey signingKey = (caKeyPair == null) ? pair.getPrivate() : caKeyPair.getPrivate();
+
+        final Date from = new Date();
+        final Date to = new Date(from.getTime() + days * 86400000L);
+        final BigInteger serial = BigInteger.valueOf(System.currentTimeMillis());
+
+        final X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
+                issuer,
+                serial,
+                from,
+                to,
+                subject,
+                publicKey
+        );
+
+        final ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").setProvider("BC").build(signingKey);
+        final X509CertificateHolder holder = certBuilder.build(signer);
+        return new JcaX509CertificateConverter().setProvider("BC").getCertificate(holder);
+    }
+}

--- a/src/test/java/biz/paluch/logging/gelf/intern/sender/GelfTCPSSLSenderConnectIntegrationTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/intern/sender/GelfTCPSSLSenderConnectIntegrationTests.java
@@ -13,6 +13,7 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
+import biz.paluch.logging.gelf.SslCertHelper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -44,13 +45,13 @@ class GelfTCPSSLSenderConnectIntegrationTests {
     @BeforeAll
     static void setupClass() throws Exception {
 
-        File file = new File("work/keystore.jks");
-        assumeTrue(file.exists());
+        final String keyStorePassword = "changeit";
+        final File file = SslCertHelper.createTestKeystoreFile(keyStorePassword);
 
         KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-        keyStore.load(new FileInputStream(file), "changeit".toCharArray());
+        keyStore.load(new FileInputStream(file), keyStorePassword.toCharArray());
         KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        kmf.init(keyStore, "changeit".toCharArray());
+        kmf.init(keyStore, keyStorePassword.toCharArray());
 
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         tmf.init(keyStore);

--- a/src/test/java/biz/paluch/logging/gelf/intern/sender/GelfTCPSSLSenderIntegrationTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/intern/sender/GelfTCPSSLSenderIntegrationTests.java
@@ -12,6 +12,7 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
+import biz.paluch.logging.gelf.SslCertHelper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -36,13 +37,13 @@ class GelfTCPSSLSenderIntegrationTests {
     @BeforeAll
     static void setupClass() throws Exception {
 
-        File file = new File("work/keystore.jks");
-        assumeTrue(file.exists());
+        final String keyStorePassword = "changeit";
+        final File file = SslCertHelper.createTestKeystoreFile(keyStorePassword);
 
         KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-        keyStore.load(new FileInputStream(file), "changeit".toCharArray());
+        keyStore.load(new FileInputStream(file), keyStorePassword.toCharArray());
         KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        kmf.init(keyStore, "changeit".toCharArray());
+        kmf.init(keyStore, keyStorePassword.toCharArray());
 
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         tmf.init(keyStore);


### PR DESCRIPTION
**Description:**
Some integration tests previously required an SSL certificate that was generated via the .travis.yml file.
As a result, these tests could not be run locally.

With this PR, the SSL certificate is generated directly within the affected tests whenever it is needed.

**Benefits:**
* Affected tests now run consistently both locally and in CI/CD.
* No more dependency on [.travis.yml](https://github.com/duoduobingbing/gelf-logging4j/blob/884b8480602edb690740104a0b5f6ac3d1f7caf1/.travis.yml).
* Test setup is simpler and more stable.