### PR TITLE
Bump versions + minor Changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,19 +14,19 @@
     <scm>
         <connection>scm:git://github.com/duoduobingbing/gelf-logging4j.git</connection>
         <developerConnection>scm:git:git@github.com:duoduobingbing/gelf-logging4j.git</developerConnection>
-        <url>http://github.com/duoduobingbing/gelf-logging4j/</url>
+        <url>https://github.com/duoduobingbing/gelf-logging4j/</url>
         <tag>HEAD</tag>
     </scm>
 
     <issueManagement>
         <system>GitHub</system>
-        <url>http://github.com/duoduobingbing/gelf-logging4j/issues</url>
+        <url>https://github.com/duoduobingbing/gelf-logging4j/issues</url>
     </issueManagement>
 
     <licenses>
         <license>
             <name>MIT License</name>
-            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <url>https://www.opensource.org/licenses/mit-license.php</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -65,15 +65,15 @@
         <maven.compiler.release>21</maven.compiler.release>
         <min.maven.version>3.9</min.maven.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <junit.version>6.1.2</junit.version>
+        <junit.version>6.1.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
         <mockito.version>5.23.0</mockito.version>
-        <jackson.version>3.2.1</jackson.version>
-        <jedis.version>7.5.3</jedis.version>
+        <jackson.version>3.2.2</jackson.version>
+        <jedis.version>8.0.0</jedis.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-pool2.version>2.13.1</commons-pool2.version>
         <slf4j-api.version>2.0.18</slf4j-api.version>
-        <logback-classic.version>1.6.0</logback-classic.version>
+        <logback-classic.version>1.6.3</logback-classic.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
@@ -81,7 +81,7 @@
         <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
         <maven-versions-plugin.version>2.21.0</maven-versions-plugin.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
-        <netty-bom.version>4.2.16.Final</netty-bom.version>
+        <netty-bom.version>4.2.17.Final</netty-bom.version>
         <maven-scm-publish-plugin.version>3.2.1</maven-scm-publish-plugin.version>
         <maven-central-publishing-plugin.version>0.11.0</maven-central-publishing-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
@@ -91,7 +91,7 @@
         <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <kafka-clients.version>4.3.1</kafka-clients.version>
-        <bouncycastle.version>1.85</bouncycastle.version>
+        <bouncycastle.version>1.85.2</bouncycastle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <lmax.disruptor.version>4.0.0</lmax.disruptor.version>
 

--- a/src/main/java/io/github/duoduobingbing/gelflogging4j/gelf/logback/hostname/HostnamePatternLayout.java
+++ b/src/main/java/io/github/duoduobingbing/gelflogging4j/gelf/logback/hostname/HostnamePatternLayout.java
@@ -13,14 +13,11 @@ import java.util.function.Supplier;
 
 public class HostnamePatternLayout extends PatternLayoutBase<ILoggingEvent> {
 
-//    private static final Map<String, String> ALL_CONVERTERS_MAP = new HashMap<String, String>(); //TODO: Legacy way, deprecated, remove once removed in PatternLayout
 
     @SuppressWarnings("rawtypes")
     public static final Map<String, Supplier<DynamicConverter>> ALL_CONVERTER_SUPPLIER_MAP = new HashMap<>();
 
     static{
-//        ALL_CONVERTERS_MAP.putAll(PatternLayout.DEFAULT_CONVERTER_MAP); //Legacy way, deprecated, remove once removed in PatternLayout
-//        ALL_CONVERTERS_MAP.put("host", HostnameConverter.class.getName()); //Legacy way, deprecated, remove once removed in PatternLayout
 
         ALL_CONVERTER_SUPPLIER_MAP.putAll(PatternLayout.DEFAULT_CONVERTER_SUPPLIER_MAP);
         ALL_CONVERTER_SUPPLIER_MAP.put("host", HostnameConverter::new);
@@ -47,6 +44,7 @@ public class HostnamePatternLayout extends PatternLayoutBase<ILoggingEvent> {
     /**
      * This will be completely removed in a later version.
      * @deprecated Use {@link #getDefaultConverterSupplierMap()} instead.
+     * Currently kept for backwards compatibility with Logback Classic 1.5.x
      * @return {@link Map}
      */
     @Deprecated(forRemoval = true)

--- a/src/test/resources/docker/Redis.Dockerfile
+++ b/src/test/resources/docker/Redis.Dockerfile
@@ -1,2 +1,2 @@
 # we have these, so our pipeline discovers them for updates via Dependabot
-FROM redis:8.8
+FROM redis:8.10


### PR DESCRIPTION
Bump versions:
- Logback -> 1.6.3
- Jedis -> 8.0.0
- Netty -> 4.2.17.Final

Clarify why function in `HostnamePatternLayout` is kept despite removal in Logback Classic in 1.6.x series.
